### PR TITLE
[replicasets/vault-example] fix syntax for 1.5.x

### DIFF
--- a/replicasets/vault-example.yaml
+++ b/replicasets/vault-example.yaml
@@ -19,17 +19,17 @@ spec:
             "env": [
               {
                 "name": "POD_NAME",
-                "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}
+                "valueFrom": {"fieldRef": {"fieldPath": "metadata.name", "apiVersion": "v1"}}
               },
-              { 
+              {
                 "name": "POD_NAMESPACE",
-                "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}
+                "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace", "apiVersion": "v1"}}
               },
-              { 
+              {
                 "name": "VAULT_ADDR",
                 "value": "http://vault:8200"
               },
-              { 
+              {
                 "name": "VAULT_CONTROLLER_ADDR",
                 "value": "http://vault-controller"
               }


### PR DESCRIPTION
Version info
```
$ minikube version
minikube version: v0.15.0
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.2", GitCommit:"08e099554f3c31f6e6f07b448ab3ed78d0520507", GitTreeState:"clean", BuildDate:"2017-01-12T07:30:54Z", GoVersion:"go1.7.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.1", GitCommit:"82450d03cb057bab0950214ef122b67c83fb11df", GitTreeState:"clean", BuildDate:"1970-01-01T00:00:00Z", GoVersion:"go1.7.1", Compiler:"gc", Platform:"linux/amd64"}
```

*before*
```
$ kubectl -n vault-controller create -f replicasets/vault-example.yaml
The ReplicaSet "vault-example" is invalid: 
* spec.template.spec.initContainers[0].env[0].valueFrom.fieldRef.apiVersion: Required value
* spec.template.spec.initContainers[0].env[1].valueFrom.fieldRef.apiVersion: Required value
```

*after*
```
$ kubectl -n vault-controller create -f replicasets/vault-example.yaml 
replicaset "vault-example" created
```
